### PR TITLE
[bug]:#27 -  인증 로직 ProtectedRoute로 리팩토링 및 중복 로그인 프롬프트 제거

### DIFF
--- a/src/pages/CreatePostPage.tsx
+++ b/src/pages/CreatePostPage.tsx
@@ -1,5 +1,5 @@
-import { useNavigate, useLocation } from 'react-router-dom';
-import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
 import { Asset, Text } from '@toss/tds-mobile';
 import { adaptive } from '@toss/tds-colors';
 import { useAuth } from '../hooks/useAuth';
@@ -7,8 +7,7 @@ import { createCase, type CaseData } from '../api/cases';
 
 function CreatePostPage() {
   const navigate = useNavigate();
-  const location = useLocation();
-  const { user, userData, isLoading } = useAuth();
+  const { user, userData } = useAuth();
   
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
@@ -28,17 +27,12 @@ function CreatePostPage() {
     setShowGuideModal(false);
   };
 
-  useEffect(() => {
-    if (!isLoading && (!user || !userData)) {
-      alert('로그인이 필요합니다.');
-      navigate('/terms', { state: { from: location } });
-    }
-  }, [isLoading, user, userData, navigate, location]);
-
   const handleSubmit = async () => {
+    // ProtectedRoute가 user와 userData를 보장합니다.
     if (!user || !userData) {
-      alert('로그인이 필요합니다.');
-      navigate('/terms', { state: { from: location } });
+      console.error("ProtectedRoute가 작동하지 않았습니다.");
+      // 만약을 위한 방어 코드이지만, 사용자에게 에러를 표시하고 함수를 중단합니다.
+      alert("사용자 정보를 확인할 수 없습니다. 다시 시도해 주세요.");
       return;
     }
 

--- a/src/pages/EditPostPage.tsx
+++ b/src/pages/EditPostPage.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useLocation, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import { Asset, Text } from '@toss/tds-mobile';
 import { adaptive } from '@toss/tds-colors';
@@ -8,8 +8,7 @@ import { getCase, updateCase } from '../api/cases';
 function EditPostPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const location = useLocation();
-  const { user, isLoading: isAuthLoading } = useAuth();
+  const { user } = useAuth();
   
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
@@ -18,20 +17,9 @@ function EditPostPage() {
 
   // Fetch post data from Firestore
   useEffect(() => {
-    if (!id) {
+    if (!id || !user) { // user는 ProtectedRoute에 의해 보장되지만, id는 여전히 확인해야 합니다.
       setError('잘못된 접근입니다.');
       setIsPostLoading(false);
-      return;
-    }
-    
-    // Wait for authentication to complete before fetching
-    if (isAuthLoading) {
-      return;
-    }
-
-    if (!user) {
-      alert('로그인이 필요합니다.');
-      navigate('/terms', { state: { from: location } });
       return;
     }
 
@@ -59,11 +47,12 @@ function EditPostPage() {
     };
 
     fetchCase();
-  }, [id, user, isAuthLoading, navigate, location]);
+  }, [id, user, navigate]);
 
   const handleSubmit = async () => {
     if (!id || !user) {
-      alert('로그인이 필요합니다.');
+      console.error("ProtectedRoute가 작동하지 않았습니다.");
+      alert('사용자 정보를 확인할 수 없습니다. 다시 시도해 주세요.');
       return;
     }
 
@@ -82,7 +71,7 @@ function EditPostPage() {
     }
   };
   
-  if (isPostLoading || isAuthLoading) {
+  if (isPostLoading) {
     return <div style={{ padding: '20px', textAlign: 'center' }}>로딩 중...</div>;
   }
 

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -6,6 +6,7 @@ import EditPostPage from '../pages/EditPostPage';
 import TermsPage from '../pages/TermsPage';
 import StaticTermsPage from '../pages/StaticTermsPage';
 import StaticMarketingPage from '../pages/StaticMarketingPage';
+import ProtectedRoute from './ProtectedRoute';
 
 // 경로를 소문자로 강제 변환하고, 필요한 경우 리다이렉트하는 컴포넌트
 function LowercaseRedirectWrapper({ children }: { children: React.ReactElement }) {
@@ -26,8 +27,22 @@ function AppRoutes() {
     <Routes>
       <Route path="/" element={<HomePage />} />
       <Route path="/case/:id" element={<CaseDetailPage />} />
-      <Route path="/create-post" element={<CreatePostPage />} />
-      <Route path="/edit-post/:id" element={<EditPostPage />} />
+      <Route 
+        path="/create-post" 
+        element={
+          <ProtectedRoute>
+            <CreatePostPage />
+          </ProtectedRoute>
+        } 
+      />
+      <Route 
+        path="/edit-post/:id" 
+        element={
+          <ProtectedRoute>
+            <EditPostPage />
+          </ProtectedRoute>
+        } 
+      />
       
       {/* 약관 동의 플로우를 위한 페이지 */}
       <Route path="/terms" element={<TermsPage />} />

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+
+// 로딩 스피너 컴포넌트 (실제 프로젝트에 맞게 수정 필요)
+const FullPageSpinner = () => (
+  <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+    <p>로딩 중...</p>
+  </div>
+);
+
+function ProtectedRoute({ children }: { children: React.ReactElement }) {
+  const { user, userData, isLoading } = useAuth();
+  const location = useLocation();
+
+  if (isLoading) {
+    // 인증 상태를 확인하는 동안 로딩 인디케이터를 보여줍니다.
+    return <FullPageSpinner />;
+  }
+
+  if (!user || !userData) {
+    // 로딩이 끝났지만 사용자가 없으면 로그인 페이지로 리디렉션합니다.
+    // 사용자가 원래 가려던 경로를 state에 담아서 보냅니다.
+    return <Navigate to="/terms" state={{ from: location }} replace />;
+  }
+
+  // 사용자가 있으면 요청된 자식 컴포넌트를 렌더링합니다.
+  return children;
+}
+
+export default ProtectedRoute;


### PR DESCRIPTION
## 🔗 Issue Number
Resolved: #27 

## 🛠️ What Did I Do?
- [ ] 로그인이 필요합니다 팝업을 삭제
- [ ] 로그인 상태 확인 로직을 ProtectedRoute 컴포넌트로 중앙 집중화

## 💬 To Reviewers
- 로그인 상태 확인 로직을 ProtectedRoute 컴포넌트로 중앙 집중화하여 중복 "로그인이 필요합니다" 프롬프트 발생 문제를 해결합니다. CreatePostPage와 EditPostPage의 개별 인증 확인 로직을 제거했습니다.

## 📸 Screenshots
- 변경 사항이 있다면 스크린샷을 첨부해주세요. 