### PR TITLE
[fix] #72 -  미션 페이지 버튼 상태 관리 및 뒤로가기 시 원래 탭 복귀 기능 추가

### DIFF
--- a/src/pages/CreatePostPage.tsx
+++ b/src/pages/CreatePostPage.tsx
@@ -8,6 +8,12 @@ function CreatePostPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const { user, userData, isLoading, login } = useAuth();
+
+  // 글쓰기 진입 전 보고 있던 탭 (작성 완료 후 복귀용)
+  const returnTab =
+    (location.state as any)?.fromTab ||
+    sessionStorage.getItem('createPostFromTab') ||
+    'HOT 게시판';
   
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
@@ -28,6 +34,14 @@ function CreatePostPage() {
       setHasShownGuide(true);
     }
   }, [hasShownGuide]);
+
+  useEffect(() => {
+    // state로 전달된 fromTab이 있으면 sessionStorage에도 저장 (새로고침/뒤로가기 대비)
+    const fromTab = (location.state as any)?.fromTab;
+    if (fromTab) {
+      sessionStorage.setItem('createPostFromTab', fromTab);
+    }
+  }, [location.state]);
 
   useEffect(() => {
     if (!isLoading && (!user || !userData)) {
@@ -322,7 +336,8 @@ function CreatePostPage() {
           }}
           onClick={() => {
             setShowSuccessModal(false);
-            navigate('/');
+            sessionStorage.removeItem('createPostFromTab');
+            navigate('/', { state: { selectedTab: returnTab }, replace: true });
           }}
         >
           <div
@@ -360,7 +375,8 @@ function CreatePostPage() {
               <button
                 onClick={() => {
                   setShowSuccessModal(false);
-                  navigate('/');
+                  sessionStorage.removeItem('createPostFromTab');
+                  navigate('/', { state: { selectedTab: returnTab }, replace: true });
                 }}
                 style={{
                   padding: '8px 16px',

--- a/src/pages/PointMissionPage.tsx
+++ b/src/pages/PointMissionPage.tsx
@@ -1,5 +1,5 @@
-import { useNavigate } from 'react-router-dom';
-import { useEffect, useState, useRef } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useEffect, useState, useRef, type CSSProperties } from 'react';
 import { Asset, Text, Spacing } from '@toss/tds-mobile';
 import { adaptive } from '@toss/tds-colors';
 import { useAuth } from '../hooks/useAuth';
@@ -11,6 +11,7 @@ import { useTossRewardAd } from '../hooks/useTossRewardAd';
 
 function PointMissionPage() {
   const navigate = useNavigate();
+  const location = useLocation();
   const { user } = useAuth();
   const [userData, setUserData] = useState<UserDocument | null>(null);
   const [loading, setLoading] = useState(true);
@@ -24,12 +25,16 @@ function PointMissionPage() {
   const { show: showRewardAd } = useTossRewardAd('ait-ad-test-rewarded-id');
 
   useEffect(() => {
-    sessionStorage.setItem('pointMissionFromTab', '재판 중');
-  }, []);
+    const fromTab =
+      (location.state as any)?.fromTab ||
+      sessionStorage.getItem('pointMissionFromTab') ||
+      'HOT 게시판';
+    sessionStorage.setItem('pointMissionFromTab', fromTab);
+  }, [location.state]);
 
   useEffect(() => {
     const handlePopState = () => {
-      const savedFromTab = sessionStorage.getItem('pointMissionFromTab') || '재판 중';
+      const savedFromTab = sessionStorage.getItem('pointMissionFromTab') || 'HOT 게시판';
       navigate('/', { state: { selectedTab: savedFromTab }, replace: true });
     };
     window.addEventListener('popstate', handlePopState);
@@ -49,6 +54,7 @@ function PointMissionPage() {
       document.removeEventListener('mousedown', handleClickOutside);
     };
   }, [showInfoPopup]);
+
 
   useEffect(() => {
     if (!user || !db) {
@@ -137,10 +143,7 @@ function PointMissionPage() {
   const isLevel0Claimed = userData?.isLevel0Claimed || false;
   const isLevel1Claimed = dailyStats.isLevel1Claimed;
   const isLevel2Claimed = dailyStats.isLevel2Claimed;
-  const isLevel3Claimed = userData?.missions?.hotCaseMission?.claimed || false;
-
-  const unlockedCount = [isLevel0Claimed, isLevel1Claimed, isLevel2Claimed, isLevel3Claimed].filter(Boolean).length;
-  const currentLevel = unlockedCount; 
+  const isLevel3Claimed = userData?.missions?.hotCaseMission?.claimed || false; 
 
   const level0ConditionMet = 
     (totalStats.voteCount >= 1 || dailyStats.voteCount >= 1) && 
@@ -161,38 +164,223 @@ function PointMissionPage() {
     @keyframes pulse-red { 0% { box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.7); } 70% { box-shadow: 0 0 0 10px rgba(239, 68, 68, 0); } 100% { box-shadow: 0 0 0 0 rgba(239, 68, 68, 0); } }
   `;
 
-  const MissionCard = ({ level, title, description, reward, limitation, conditionMet, isClaimed, buttonColor, completedColor, missionType }: any) => {
+  const MissionCard = ({ level, title, description, reward, limitation, conditionMet, isClaimed, missionType, buttonText }: any) => {
     const canClaim = conditionMet && !isClaimed;
     const animationName = level === 0 ? 'pulse-blue' : level === 1 ? 'pulse-green' : level === 2 ? 'pulse-orange' : 'pulse-red';
+    const [showInfoPopup, setShowInfoPopup] = useState(false);
+    const infoPopupRef = useRef<HTMLDivElement>(null);
+    const [tooltipPosition, setTooltipPosition] = useState({ top: 0, left: 0, right: 0 });
+    
+    const infoMessages: { [key: number]: string } = {
+      0: '계정당 1회만 가능',
+      1: '하루 1회 제한',
+      2: '하루 1회 제한',
+      3: '게시물당 1개 지급'
+    };
+    
+    const infoMessage = infoMessages[level] || '';
+    
+    useEffect(() => {
+      const handleClickOutside = (event: MouseEvent) => {
+        if (infoPopupRef.current && !infoPopupRef.current.contains(event.target as Node)) {
+          setShowInfoPopup(false);
+        }
+      };
+      if (showInfoPopup) {
+        document.addEventListener('mousedown', handleClickOutside);
+        // 정보 아이콘의 위치 계산
+        if (infoPopupRef.current) {
+          const rect = infoPopupRef.current.getBoundingClientRect();
+          const parentRect = infoPopupRef.current.closest('[data-mission-card]')?.getBoundingClientRect();
+          if (parentRect) {
+            setTooltipPosition({
+              top: rect.top - parentRect.top - 8,
+              left: rect.left - parentRect.left + rect.width / 2,
+              right: parentRect.right - rect.right
+            });
+          }
+        }
+      }
+      return () => {
+        document.removeEventListener('mousedown', handleClickOutside);
+      };
+    }, [showInfoPopup]);
 
     return (
-      <div style={{ marginBottom: '8px', padding: '0 21px', display: 'flex', justifyContent: 'center' }}>
+      <div style={{ marginBottom: '12px', padding: '0', display: 'flex', justifyContent: 'center', width: '100%', boxSizing: 'border-box', marginLeft: '0', marginRight: '0' }}>
         <style>{pulseKeyframes}</style>
-        <div style={{ width: '100%', maxWidth: '333px', position: 'relative' }}>
-          <div style={{ width: '100%', borderRadius: '10px', overflow: 'hidden', boxShadow: '0px 2px 2px 0px rgba(0, 0, 0, 0.25)', position: 'relative' }}>
-            <div style={{ width: '100%', height: '34px', background: level === 0 ? 'linear-gradient(120deg, #64a8ff 0%, #7e74fb 76.19%, #a02ff5 100%)' : level === 1 ? '#15c47e' : level === 2 ? '#ffb331' : '#f66570', borderRadius: '10px 10px 0 0', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '0 20px', position: 'relative', boxSizing: 'border-box' }}>
-              <div style={{ position: 'absolute', left: '20px', padding: '1px 4px', backgroundColor: level === 0 ? '#3182F628' : level === 1 ? '#02A26228' : level === 2 ? '#FFB33128' : '#F0445228', borderRadius: '4px', fontSize: '12px', fontWeight: '600', color: level === 0 ? '#1976D2' : level === 1 ? '#02A262' : level === 2 ? '#FFB331' : '#D32F2F' }}>Level {level}</div>
-              <span style={{ fontSize: '14px', fontWeight: '600', color: 'white', textAlign: 'center' }}>{title}</span>
+        <div data-mission-card style={{ width: '100%', maxWidth: '333px', position: 'relative', margin: '0 auto', marginLeft: '14px'}}>
+          {/* 말풍선 - 최상위 컨테이너에 렌더링 */}
+          {showInfoPopup && (
+            <div style={{ 
+              position: 'absolute', 
+              right: `${tooltipPosition.right - 8}px`,
+              top: `${tooltipPosition.top + 4}px`,
+              transform: 'translateY(-100%)',
+              marginTop: '-8px',
+              backgroundColor: 'white', 
+              padding: '8px 12px', 
+              borderRadius: '8px', 
+              boxShadow: '0px 2px 8px rgba(0, 0, 0, 0.15)', 
+              zIndex: 1002, 
+              whiteSpace: 'nowrap',
+              fontSize: '13px',
+              color: '#191F28',
+              display: 'inline-block',
+              lineHeight: '1.4'
+            }}>
+              <Text color="#191F28" typography="t7" fontWeight="medium" style={{ fontSize: '13px', whiteSpace: 'nowrap', display: 'inline' }}>
+                {infoMessage}
+              </Text>
+              {/* 말풍선 꼬리 - 정보 아이콘을 가리키도록 오른쪽에 위치 */}
+              <div style={{
+                position: 'absolute',
+                bottom: '-6px',
+                right: '12px',
+                width: 0,
+                height: 0,
+                borderLeft: '6px solid transparent',
+                borderRight: '6px solid transparent',
+                borderTop: '6px solid white'
+              }} />
             </div>
-            <div style={{ width: '100%', minHeight: 'auto', backgroundColor: level === 0 ? '#c9e2ff' : level === 1 ? '#aeefd5' : level === 2 ? '#ffefbf' : '#ffd4d6', borderRadius: '0 0 10px 10px', padding: '20px 70px 20px 20px', display: 'flex', flexDirection: 'column', gap: '4px', position: 'relative', boxSizing: 'border-box', wordBreak: 'keep-all', overflowWrap: 'break-word' }}>
-              <div style={{ fontSize: '14px', fontWeight: '700', color: '#191F28', marginBottom: '4px', wordBreak: 'keep-all', overflowWrap: 'break-word' }}>{description}</div>
-              <div style={{ display: 'flex', alignItems: 'center', gap: '4px', marginBottom: '4px' }}>
-                <span style={{ fontSize: '14px', fontWeight: '500', color: '#191F28' }}>판사봉 : </span>
-                <span style={{ fontSize: '14px', fontWeight: '700', color: '#191F28' }}>{reward}개</span>
-              </div>
-              <div style={{ fontSize: '14px', fontWeight: '500', color: '#191F28' }}>{limitation}</div>
-              <div style={{ position: 'absolute', right: '20px', top: '50%', transform: 'translateY(-50%)', zIndex: 100, pointerEvents: 'auto' }}>
-                {isClaimed ? (
-                  <span style={{ fontSize: '14px', fontWeight: '700', color: completedColor, display: 'block' }}>완료 ✓</span>
-                ) : (
-                  <button
-                    onClick={() => { if (canClaim) handleClaim(missionType, reward); }}
-                    disabled={isClaiming || !canClaim}
-                    style={{ width: '51px', height: '33px', backgroundColor: canClaim ? buttonColor : '#d0d5dd', color: 'white', border: 'none', borderRadius: '5px', fontSize: '13px', fontWeight: '600', cursor: (isClaiming || !canClaim) ? 'not-allowed' : 'pointer', opacity: isClaiming ? 0.6 : 1, whiteSpace: 'nowrap', display: 'block', animation: canClaim ? `${animationName} 2s infinite` : 'none', transformOrigin: 'center' }}
+          )}
+          <div style={{ width: '100%', borderRadius: '12px', overflow: 'hidden', boxShadow: '0px 0px 2px 0px rgba(0, 0, 0, 0.25)', border: '1px solid #C9A86A', position: 'relative', backgroundColor: '#F7F3EE', padding: '4px' }}>
+            <div style={{ width: '100%', borderRadius: '10px', boxShadow: 'inset 0 0 0 1px #C9A86A', backgroundColor: '#F7F3EE', padding: '8px 14px', display: 'flex', flexDirection: 'column', gap: '2px', position: 'relative', boxSizing: 'border-box' }}>
+              {/* 제목과 정보 아이콘 */}
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '0px' }}>
+                <Text display="block" color="#3A2E25" typography="st8" fontWeight="bold" style={{ fontSize: '18px' }}>
+                  {title}
+                </Text>
+                <div ref={infoPopupRef} style={{ position: 'relative', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>
+                  <div 
+                    onClick={() => setShowInfoPopup(!showInfoPopup)} 
+                    style={{ cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
                   >
-                    받기
-                  </button>
-                )}
+                    <Asset.Icon
+                      frameShape={Asset.frameShape.CleanW16}
+                      backgroundColor="transparent"
+                      name="icon-info-circle-mono"
+                      color="#c9a86bcc"
+                      aria-hidden={true}
+                      ratio="1/1"
+                    />
+                  </div>
+                </div>
+              </div>
+              
+              {/* 설명 */}
+              <Text color="#4F2810" typography="t7" fontWeight="regular" style={{ fontSize: '13px', lineHeight: '1.4', marginBottom: '0px' }}>
+                {description}
+              </Text>
+              
+              {/* 조건 */}
+              <Text color={adaptive.grey800} typography="t6" fontWeight="bold" style={{ fontSize: '14px', marginBottom: '0px' }}>
+                {limitation}
+              </Text>
+              
+              {/* 보상 */}
+              <div style={{ display: 'flex', alignItems: 'center', gap: '4px', marginBottom: 'auto' }}>
+                <Text color={adaptive.grey700} typography="t7" fontWeight="medium" style={{ fontSize: '13px' }}>
+                  보상 :{' '}
+                </Text>
+                <Text color={adaptive.grey700} typography="t7" fontWeight="bold" style={{ fontSize: '13px' }}>
+                  판사봉 {reward}개
+                </Text>
+              </div>
+              
+              {/* 버튼 - 오른쪽 아래 */}
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0px', justifyContent: 'flex-end', marginTop: 'auto' }}>
+                {(() => {
+                  const claimedLabel =
+                    missionType === 'LEVEL_0'
+                      ? '✓ 등록 완료'
+                      : missionType === 'LEVEL_3'
+                        ? '✓ 등재 완료'
+                        : '✓ 제출 완료';
+
+                  // 공통 버튼 스타일
+                  const baseButtonStyle: CSSProperties = {
+                    minWidth: '131px',
+                    height: '27px',
+                    border: 'none',
+                    borderRadius: '5px',
+                    fontSize: '13px',
+                    fontWeight: 400,
+                    whiteSpace: 'nowrap',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: '6px',
+                    padding: '0 12px',
+                    transformOrigin: 'center',
+                  };
+
+                  // 완료 상태 (세 번째 사진처럼)
+                  if (isClaimed) {
+                    return (
+                      <button
+                        aria-disabled={true}
+                        style={{
+                          ...baseButtonStyle,
+                          backgroundColor: '#8C6B57',
+                          color: '#ffffff',
+                          WebkitTextFillColor: '#ffffff',
+                          cursor: 'default',
+                          opacity: 1,
+                          pointerEvents: 'none',
+                        }}
+                      >
+                        {claimedLabel}
+                      </button>
+                    );
+                  }
+
+                  // 활성 상태 (첫 번째 사진처럼)
+                  if (canClaim) {
+                    return (
+                      <button
+                        onClick={() => handleClaim(missionType, reward)}
+                        disabled={isClaiming}
+                        style={{
+                          ...baseButtonStyle,
+                          background: 'linear-gradient(120deg, #3a2e25 0%, #8c6b57 100%)',
+                          color: '#ffffff',
+                          WebkitTextFillColor: '#ffffff',
+                          cursor: isClaiming ? 'not-allowed' : 'pointer',
+                          opacity: isClaiming ? 0.6 : 1,
+                          animation: `${animationName} 2s infinite`,
+                        }}
+                      >
+                        {buttonText || '받기'}
+                      </button>
+                    );
+                  }
+
+                  // 잠금 상태 (기존 회색 잠금 버튼)
+                  return (
+                    <button
+                      disabled={true}
+                      style={{
+                        ...baseButtonStyle,
+                        backgroundColor: '#6B7684',
+                        color: '#9E9E9E',
+                        cursor: 'not-allowed',
+                        opacity: 1,
+                      }}
+                    >
+                      <Asset.Icon
+                        frameShape={Asset.frameShape.CleanW16}
+                        backgroundColor="transparent"
+                        name="icon-lock-mono"
+                        color="#9E9E9E"
+                        aria-hidden={true}
+                        ratio="1/1"
+                      />
+                      {buttonText || '받기'}
+                    </button>
+                  );
+                })()}
               </div>
             </div>
           </div>
@@ -202,44 +390,118 @@ function PointMissionPage() {
   };
 
   return (
-    <div style={{ backgroundColor: 'white', minHeight: '100vh', width: '100%', boxSizing: 'border-box', display: 'flex', flexDirection: 'column', paddingBottom: '24px' }}>
-      <Spacing size={29} />
-      <div style={{ padding: '0 20px', marginBottom: '21px', marginTop: '15px', display: 'flex', justifyContent: 'center', alignItems: 'flex-start', gap: '40px' }}>
-        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', marginTop: '0px' }}>
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '8px', marginBottom: '8px' }}>
-            <span style={{ fontSize: '14px', fontWeight: '700', color: '#191F28' }}>Level {currentLevel} </span>
-            <span style={{ fontSize: '14px', fontWeight: '700', color: '#4593fc' }}>진행 중</span>
-          </div>
-          <div style={{ marginBottom: '12px', fontSize: '20px', fontWeight: '700', color: '#191F28', display: 'block', textAlign: 'center' }}>{unlockedCount} / 4</div>
-          <div style={{ width: '120px', height: '10px', backgroundColor: '#e5e8eb', borderRadius: '5px', overflow: 'hidden', marginTop: '12px' }}>
-            <div style={{ width: `${(unlockedCount / 4) * 100}%`, height: '100%', backgroundColor: '#4593fc', borderRadius: '5px', transition: 'width 0.3s ease' }} />
-          </div>
+    <div style={{ backgroundColor: 'white', minHeight: '100vh', width: '100%', boxSizing: 'border-box', display: 'flex', flexDirection: 'column', paddingBottom: '24px', paddingLeft: '0', paddingRight: '0' }}>
+      <Spacing size={10} />
+      <div style={{ padding: '10px 10px 5px 10px', backgroundColor: '#FCF8F2', width: '100%', boxSizing: 'border-box' }}>
+        <div style={{ padding: '0 10px', marginBottom: '11px', textAlign: 'center' }}>
+          <Text color={adaptive.grey800} typography="t4" fontWeight="bold" style={{ fontSize: '20px' }}>
+            오늘의 판결 업무
+          </Text>
         </div>
-        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '4px', marginTop: '0px' }}>
-          <Asset.Icon frameShape={Asset.frameShape.CleanW40} backgroundColor="transparent" name="icon-gavel" aria-hidden={true} ratio="1/1" />
-          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-            <div ref={infoPopupRef} style={{ position: 'relative', display: 'flex', alignItems: 'center' }}>
-              <Asset.Icon frameShape={Asset.frameShape.CleanW16} backgroundColor="transparent" name="icon-info-circle-mono-16" aria-hidden={true} ratio="1/1" onClick={() => setShowInfoPopup(!showInfoPopup)} style={{ cursor: 'pointer' }} />
-              {showInfoPopup && (
-                <div style={{ position: 'absolute', top: '24px', right: '0', backgroundColor: 'white', padding: '12px', borderRadius: '8px', boxShadow: '0px 2px 8px rgba(0, 0, 0, 0.15)', zIndex: 1000, minWidth: '200px' }}>
-                  <Text color={adaptive.grey900} typography="t7" fontWeight="medium">판사봉 50개 모으면 5P 교환 가능!</Text>
-                  <button onClick={() => setShowInfoPopup(false)} style={{ marginTop: '8px', padding: '4px 8px', backgroundColor: adaptive.blue500, color: 'white', border: 'none', borderRadius: '4px', fontSize: '12px', cursor: 'pointer' }}>확인</button>
+        <div style={{ width: '100%', height: '1px', backgroundColor: '#ccb284', opacity: 0.6, marginBottom: '11px' }} />
+        <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'flex-start', padding: '0 10px', marginBottom: '10px', gap: '80px' }}>
+          {/* 왼쪽: 판사봉 정보 */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '11px', alignItems: 'center', marginTop: '8px' }}>
+            <Asset.Icon frameShape={Asset.frameShape.CleanW40} backgroundColor="transparent" name="icon-gavel" aria-hidden={true} ratio="1/1" />
+            <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+              <Text display="block" color={adaptive.grey800} typography="t5" fontWeight="bold">
+                판사봉 {currentGavel}
+              </Text>
+              <Text display="block" color={adaptive.grey600} typography="t5" fontWeight="bold">
+                / 50
+              </Text>
+              <div ref={infoPopupRef} style={{ position: 'relative', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>
+                <div 
+                  onClick={() => setShowInfoPopup(!showInfoPopup)} 
+                  style={{ cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                >
+                  <Asset.Icon frameShape={{ width: 11, height: 11 }} backgroundColor="transparent" name="icon-info-circle-mono-16" aria-hidden={true} ratio="1/1" />
                 </div>
-              )}
+                {showInfoPopup && (
+                  <div style={{ 
+                    position: 'absolute', 
+                    left: '50%',
+                    bottom: '100%',
+                    transform: 'translateX(-50%)',
+                    marginBottom: '8px',
+                    backgroundColor: 'white', 
+                    padding: '8px 12px', 
+                    borderRadius: '8px', 
+                    boxShadow: '0px 2px 8px rgba(0, 0, 0, 0.15)', 
+                    zIndex: 1000, 
+                    whiteSpace: 'nowrap',
+                    fontSize: '13px',
+                    color: '#191F28',
+                    display: 'inline-block',
+                    lineHeight: '1.4'
+                  }}>
+                    <Text color="#191F28" typography="t7" fontWeight="medium" style={{ fontSize: '13px', whiteSpace: 'nowrap', display: 'inline' }}>
+                      50개 모으면 5P 교환 가능
+                    </Text>
+                    {/* 말풍선 꼬리 */}
+                    <div style={{
+                      position: 'absolute',
+                      bottom: '-6px',
+                      left: '50%',
+                      transform: 'translateX(-50%)',
+                      width: 0,
+                      height: 0,
+                      borderLeft: '6px solid transparent',
+                      borderRight: '6px solid transparent',
+                      borderTop: '6px solid white'
+                    }} />
+                  </div>
+                )}
+              </div>
             </div>
-            <span style={{ fontSize: '18px', fontWeight: '700', color: '#191F28' }}>판사봉 {currentGavel}</span>
-            <span style={{ fontSize: '18px', fontWeight: '700', color: '#6b7684' }}> / 50</span>
+            <button 
+              onClick={handleExchange} 
+              disabled={!canExchange || isExchanging} 
+              style={{ 
+                padding: '0', 
+                backgroundColor: 'transparent', 
+                color: adaptive.blue500, 
+                border: 'none', 
+                fontSize: '14px', 
+                fontWeight: '700', 
+                cursor: (canExchange && !isExchanging) ? 'pointer' : 'not-allowed', 
+                whiteSpace: 'nowrap', 
+                textAlign: 'center',
+                opacity: (canExchange && !isExchanging) ? 1 : 0.5 
+              }}
+            >
+              {isExchanging ? '교환 중...' : '교환하기 >'}
+            </button>
           </div>
-          <button onClick={handleExchange} disabled={!canExchange || isExchanging} style={{ padding: '0', backgroundColor: 'transparent', color: '#4593fc', border: 'none', fontSize: '14px', fontWeight: '700', cursor: (canExchange && !isExchanging) ? 'pointer' : 'not-allowed', whiteSpace: 'nowrap', textDecoration: 'underline', opacity: (canExchange && !isExchanging) ? 1 : 0.5 }}>{isExchanging ? '교환 중...' : '교환하기 >'}</button>
+          
+          {/* 오른쪽: 진행 현황 */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', alignItems: 'center', marginTop: '12px', marginLeft: '-20px' }}>
+            <Text color="#6B7684" typography="t7" fontWeight="medium" style={{ marginBottom: '4px' }}>
+              진행 현황
+            </Text>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '2px', alignItems: 'center' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                <Text color="#6B7684" typography="t6" fontWeight="bold">✓ 투표 </Text>
+                <Text color="#3182F6" typography="t6" fontWeight="bold">{dailyStats.voteCount}</Text>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                <Text color="#6B7684" typography="t6" fontWeight="bold">✓ 댓글 </Text>
+                <Text color="#3182F6" typography="t6" fontWeight="bold">{dailyStats.commentCount}</Text>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                <Text color="#6B7684" typography="t6" fontWeight="bold">✓ 게시물 </Text>
+                <Text color="#3182F6" typography="t6" fontWeight="bold">{myPostCount}</Text>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
-      <Spacing size={15} />
-      <div style={{ width: '100%', height: '1px', backgroundColor: adaptive.grey200 }} />
-      <div style={{ width: '100%', backgroundColor: '#f2f4f6', paddingTop: '10px', paddingBottom: '24px' }}>
-        <MissionCard level={0} title="첫 이벤트" description="투표 1개 + 댓글 1개 + 게시물 1개" reward={100} limitation="계정당 1회 한정" conditionMet={level0ConditionMet} isClaimed={isLevel0Claimed} buttonColor={adaptive.blue400} completedColor={adaptive.blue300} missionType="LEVEL_0" />
-        <MissionCard level={1} title="초보 미션" description="투표 5개" reward={30} limitation="하루 1번" conditionMet={level1ConditionMet} isClaimed={isLevel1Claimed} buttonColor={adaptive.green500} completedColor={adaptive.green300} missionType="LEVEL_1" />
-        <MissionCard level={2} title="참여 미션" description="댓글 3개" reward={60} limitation="하루 1번" conditionMet={level2ConditionMet} isClaimed={isLevel2Claimed} buttonColor={adaptive.orange400} completedColor={adaptive.orange300} missionType="LEVEL_2" />
-        <MissionCard level={3} title="핵심 기여" description="화제의 재판 기록에 오르기" reward={100} limitation="게시물당 1번" conditionMet={level3ConditionMet} isClaimed={isLevel3Claimed} buttonColor={adaptive.red400} completedColor={adaptive.red300} missionType="LEVEL_3" />
+      
+      <div style={{ width: '100%', backgroundColor: 'white', paddingTop: '8px', paddingBottom: '24px', paddingLeft: '10px', paddingRight: '10px', boxSizing: 'border-box', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+        <MissionCard level={0} title="첫 이벤트" description="첫 사건에 참여해 배심원으로 공식 등록해보세요" reward={100} limitation="투표 1회 + 댓글 1개 + 게시물 1개" conditionMet={level0ConditionMet} isClaimed={isLevel0Claimed} missionType="LEVEL_0" buttonText="배심원 등록" />
+        <MissionCard level={1} title="일반 사건 심리" description="소비 사건을 살펴보고 당신의 판단을 투표로 남겨주세요" reward={30} limitation="투표 5회" conditionMet={level1ConditionMet} isClaimed={isLevel1Claimed} missionType="LEVEL_1" buttonText="판결 제출하기" />
+        <MissionCard level={2} title="판결 사유 제출" description="판결 이유를 댓글로 남겨 사건 해결을 도와주세요" reward={60} limitation="댓글 3회" conditionMet={level2ConditionMet} isClaimed={isLevel2Claimed} missionType="LEVEL_2" buttonText="의견 제출하기" />
+        <MissionCard level={3} title="핵심 기여 사건" description="많은 시민이 주목하는 재판 기록의 주인공이 되어보세요" reward={100} limitation="'화제의 재판 기록'에 등재" conditionMet={level3ConditionMet} isClaimed={isLevel3Claimed} missionType="LEVEL_3" buttonText="화제의 주인공" />
       </div>
     </div>
   );


### PR DESCRIPTION
## 🔗 Issue Number
Resolved: #72 

## 🛠️ What Did I Do?
- 미션 카드 버튼: 잠금/활성/완료 3단계 상태 구현
- 활성 버튼: 갈색 그라데이션 배경, 흰색 텍스트
- 완료 버튼: 갈색 배경, '✓ 등록/제출/등재 완료' 텍스트
- 미션 페이지 뒤로가기: 원래 보던 탭으로 복귀
- 글쓰기 완료 후: 원래 보던 탭으로 복귀